### PR TITLE
Add bootstrap node into API Backend

### DIFF
--- a/libvirt/haproxy/haproxy_C155F2U31.cfg
+++ b/libvirt/haproxy/haproxy_C155F2U31.cfg
@@ -115,24 +115,28 @@ frontend https-all
 backend masters-00
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.126.10:6443 check
     server      master1 192.168.126.11:6443 check
     server      master2 192.168.126.12:6443 check
     server      master3 192.168.126.13:6443 check
 backend masters-01
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.1.10:6443 check
     server      master1 192.168.1.11:6443 check
     server      master2 192.168.1.12:6443 check
     server      master3 192.168.1.13:6443 check
 backend masters-02
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.2.10:6443 check
     server      master1 192.168.2.11:6443 check
     server      master2 192.168.2.12:6443 check
     server      master3 192.168.2.13:6443 check
 backend masters-03
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.3.10:6443 check
     server      master1 192.168.3.11:6443 check
     server      master2 192.168.3.12:6443 check
     server      master3 192.168.3.13:6443 check

--- a/libvirt/haproxy/haproxy_C155F2U33.cfg
+++ b/libvirt/haproxy/haproxy_C155F2U33.cfg
@@ -116,24 +116,28 @@ frontend https-all
 backend masters-00
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.126.10:6443 check
     server      master1 192.168.126.11:6443 check
     server      master2 192.168.126.12:6443 check
     server      master3 192.168.126.13:6443 check
 backend masters-01
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.1.10:6443 check
     server      master1 192.168.1.11:6443 check
     server      master2 192.168.1.12:6443 check
     server      master3 192.168.1.13:6443 check
 backend masters-02
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.2.10:6443 check
     server      master1 192.168.2.11:6443 check
     server      master2 192.168.2.12:6443 check
     server      master3 192.168.2.13:6443 check
 backend masters-03
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.3.10:6443 check
     server      master1 192.168.3.11:6443 check
     server      master2 192.168.3.12:6443 check
     server      master3 192.168.3.13:6443 check

--- a/libvirt/haproxy/haproxy_C155F2U35.cfg
+++ b/libvirt/haproxy/haproxy_C155F2U35.cfg
@@ -115,24 +115,28 @@ frontend https-all
 backend masters-00
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.126.10:6443 check
     server      master1 192.168.126.11:6443 check
     server      master2 192.168.126.12:6443 check
     server      master3 192.168.126.13:6443 check
 backend masters-01
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.1.10:6443 check
     server      master1 192.168.1.11:6443 check
     server      master2 192.168.1.12:6443 check
     server      master3 192.168.1.13:6443 check
 backend masters-02
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.2.10:6443 check
     server      master1 192.168.2.11:6443 check
     server      master2 192.168.2.12:6443 check
     server      master3 192.168.2.13:6443 check
 backend masters-03
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.3.10:6443 check
     server      master1 192.168.3.11:6443 check
     server      master2 192.168.3.12:6443 check
     server      master3 192.168.3.13:6443 check

--- a/libvirt/haproxy/haproxy_lnxocp01.cfg
+++ b/libvirt/haproxy/haproxy_lnxocp01.cfg
@@ -125,30 +125,35 @@ frontend https-all
 backend masters-00
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.126.10:6443 check
     server      master1 192.168.126.11:6443 check
     server      master2 192.168.126.12:6443 check
     server      master3 192.168.126.13:6443 check
 backend masters-01
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.1.10:6443 check
     server      master1 192.168.1.11:6443 check
     server      master2 192.168.1.12:6443 check
     server      master3 192.168.1.13:6443 check
 backend masters-02
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.2.10:6443 check
     server      master1 192.168.2.11:6443 check
     server      master2 192.168.2.12:6443 check
     server      master3 192.168.2.13:6443 check
 backend masters-03
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.3.10:6443 check
     server      master1 192.168.3.11:6443 check
     server      master2 192.168.3.12:6443 check
     server      master3 192.168.3.13:6443 check
 backend masters-04
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.4.10:6443 check
     server      master1 192.168.4.11:6443 check
     server      master2 192.168.4.12:6443 check
     server      master3 192.168.4.13:6443 check

--- a/libvirt/haproxy/haproxy_lnxocp02.cfg
+++ b/libvirt/haproxy/haproxy_lnxocp02.cfg
@@ -125,30 +125,35 @@ frontend https-all
 backend masters-00
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.126.10:6443 check
     server      master1 192.168.126.11:6443 check
     server      master2 192.168.126.12:6443 check
     server      master3 192.168.126.13:6443 check
 backend masters-01
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.1.10:6443 check
     server      master1 192.168.1.11:6443 check
     server      master2 192.168.1.12:6443 check
     server      master3 192.168.1.13:6443 check
 backend masters-02
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.2.10:6443 check
     server      master1 192.168.2.11:6443 check
     server      master2 192.168.2.12:6443 check
     server      master3 192.168.2.13:6443 check
 backend masters-03
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.3.10:6443 check
     server      master1 192.168.3.11:6443 check
     server      master2 192.168.3.12:6443 check
     server      master3 192.168.3.13:6443 check
 backend masters-04
     mode        tcp
     balance     roundrobin
+    server      bootstrap 192.168.4.10:6443 check
     server      master1 192.168.4.11:6443 check
     server      master2 192.168.4.12:6443 check
     server      master3 192.168.4.13:6443 check


### PR DESCRIPTION
In a local libvirt install the API Loadbalancing is handled by dnsmasq,
in tests we use HAProxy. In the libvirt IPI deploy, the bootstrap node
is added to the dnsmasq pool for the API, until the bootstrap is torn
down. We should do the same for HAProxy.