### PR TITLE
fix port forward related code in tunnel.sh and profile_lnxocp03.yaml

### DIFF
--- a/libvirt/tunnel/profile_lnxocp03.yaml
+++ b/libvirt/tunnel/profile_lnxocp03.yaml
@@ -1,7 +1,7 @@
 profile:
   arch: "s390x"
   cluster_capacity: 2
-  cluster_id: 0
+  cluster_id: 3
   environment: "bastion-z"
 libvirt:
   bastion-port: 16512
@@ -16,8 +16,8 @@ https:
   bastion-port: 8446
   target-port: 443
 bastion0ssh:
-  bastion-port: 1076
+  bastion-port: 1036
   target-port: 22
 bastion1ssh:
-  bastion-port: 1077
+  bastion-port: 1046
   target-port: 22

--- a/libvirt/tunnel/tunnel.sh
+++ b/libvirt/tunnel/tunnel.sh
@@ -47,7 +47,7 @@ PORTS+=" -R $(yq eval '.https.bastion-port' ${filename}):127.0.0.1:$(yq eval '.h
 
 declare -a BASTION_ADDRS=( "192.168.126.10" "192.168.1.10" "192.168.2.10" "192.168.3.10" "192.168.4.10" "192.168.6.10" )
 
-for CLUSTER_NUM in $(seq 0 ${CLUSTER_CAPACITY})
+for CLUSTER_NUM in $(seq 0 $((CLUSTER_CAPACITY-1)) )
 do
 	BASTION_SSH=".bastion${CLUSTER_NUM}ssh"
 	BASTION_ADDR=${BASTION_ADDRS[${CLUSTER_NUM}]}


### PR DESCRIPTION
I corrected the number of port forwards are created for the bootstrap nodes called `bastion-port`. The capacity of clusters has to be reduced by 1, because the loop started to count from 0. Also had to correct the ports for `lnxocp03` and the `cluster_id`.